### PR TITLE
Fix exception on unnexpected warning format

### DIFF
--- a/check-doxygen-warnings.py
+++ b/check-doxygen-warnings.py
@@ -30,7 +30,7 @@ def filter_doxygen_messages(filenames, messages):
     interesting_messages = [
         msg.strip()
         for msg in messages
-        if any((os.path.samefile(msg.partition(":")[0], f) for f in filenames))
+        if any((os.path.isfile(msg.partition(":")[0]) and os.path.samefile(msg.partition(":")[0], f) for f in filenames))
     ]
 
     # Filter some common false positives


### PR DESCRIPTION
This should fix the following exception caused by an unexpectly formated line in the doxygen warnings:

FileNotFoundError: [Errno 2] No such file or directory: '\n'